### PR TITLE
lemmas for converse of iadd, isub overflow check.

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-  "spec": "./spec_isub_fail.ini",
+  "spec": "./spec_suck_fail.ini",
   "prelude": "./exp.smt2",
   "lemmas": "./lemmas.k",
   "bin_runtime": "./D0Impl.bin-runtime",

--- a/lemmas.k
+++ b/lemmas.k
@@ -1,4 +1,12 @@
-rule #take(N, #padToWidth(N, X) ++ Z ) => X
+rule #take(N, #padToWidth(N, WS) ++ WS' ) => #padToWidth(N, WS)
+
+// shifting trick in the beginning of ABI thing:
+// dividing by 16^56 == 2^224 is the same as shifting to last 4 bytes
+rule #asWord(W : X : Y : Z : WS) /Int 26959946667150639794667015087019630673637144422540572481103610249216 => #asWord(W : X : Y : Z : .WordStack)
+
+rule #asWord(#padToWidth(32, #asByteStack(#unsigned(X)))) => #unsigned(X)
+  requires #rangeSInt(256, X)
+
 rule #asWord( #asByteStack( X ) ) => X
 
 rule #hashedLocation("DappHub", BASE, OFFSET OFFSETS) => #hashedLocation("DappHub", keccakIntList(BASE OFFSET),       OFFSETS)

--- a/lemmas.k
+++ b/lemmas.k
@@ -1,22 +1,65 @@
 rule #take(N, #padToWidth(N, X) ++ Z ) => X
 rule #asWord( #asByteStack( X ) ) => X
 
-rule (#unsigned(A) -Word #unsigned(B)) => #unsigned(A -Int B)
-  requires minSInt256 <=Int A andBool A <=Int maxSInt256
-  andBool  minSInt256 <=Int B andBool B <=Int maxSInt256
-  andBool  minSInt256 <=Int (A -Int B)
-  andBool  (A -Int B) <=Int maxSInt256
+rule #hashedLocation("DappHub", BASE, OFFSET OFFSETS) => #hashedLocation("DappHub", keccakIntList(BASE OFFSET),       OFFSETS)
 
+// propositional rules
+rule notBool (P orBool Q) => (notBool P) andBool (notBool Q)
+rule notBool (P andBool Q) => (notBool P) orBool (notBool Q)
+rule notBool (notBool P) => P
+
+// lemmas to tell us that our non-overflow conditions are sufficient
+rule (#unsigned(A) -Word #unsigned(B)) => #unsigned(A -Int B)
+  requires #rangeSInt(256, A)
+  andBool #rangeSInt(256, B)
+  andBool #rangeSInt(256, A -Int B)
+
+// n.b. how + cases use +Int because of earlier application of +Word 
 rule (#unsigned(A) +Int #unsigned(B)) => #unsigned(A +Int B)
-  requires minSInt256 <=Int A andBool A <=Int maxSInt256
-  andBool  minSInt256 <=Int B andBool B <=Int maxSInt256
-  andBool  minSInt256 <=Int (A +Int B)
-  andBool  (A +Int B) <=Int maxSInt256
+  requires #rangeSInt(256, A)
+  andBool #rangeSInt(256, B)
+  andBool #rangeSInt(256, A +Int B)
+
+rule #signed(#unsigned(W)) => W
+  requires #rangeSInt(256, W)
+
+rule #unsigned(#signed(W)) => W
+  requires #rangeUInt(256, W)
 
 rule W0 s<Word W1 => #signed(W0) <Word #signed(W1)
 
-rule #signed(#unsigned(W)) => W
-rule #unsigned(#signed(W)) => W
+// lemmas to tell us that our non-overflow conditions are necessary for
+// the overflow checks in iadd and isub
 
-// rule W <Int #if B #then W0 #else W1 #fi => (B impliesBool
-rule #hashedLocation("DappHub", BASE, OFFSET OFFSETS) => #hashedLocation("DappHub", keccakIntList(BASE OFFSET),       OFFSETS)
+// these just encode implications
+// (¬A or B) is (A -> B) 
+rule (notBool (0 <Int B))
+    orBool
+     (#signed (#unsigned(A) -Word #unsigned(B)) <Int A)
+    => (A -Int B >=Int minSInt256)	      
+  requires #rangeSInt(256, A)
+  andBool  #rangeSInt(256, B)
+
+rule (notBool (B <Int 0))
+    orBool
+     (A <Int #signed (#unsigned(A) -Word #unsigned(B)))
+    => (A -Int B <=Int maxSInt256)	      
+  requires #rangeSInt(256, A)
+  andBool  #rangeSInt(256, B)
+
+// n.b. how + cases use chop and +Int because of earlier application of +Word 
+rule (notBool (0 <Int B))
+    orBool
+     (A <Int #signed (chop (#unsigned (A) +Int #unsigned (B))))
+    => (A +Int B <=Int maxSInt256)
+  requires #rangeSInt(256, A)
+  andBool  #rangeSInt(256, B)
+
+rule (notBool (B <Int 0))
+    orBool
+     (#signed (chop (#unsigned (A) +Int #unsigned (B))) <Int A)
+    => (A +Int B >=Int minSInt256)
+  requires #rangeSInt(256, A)
+  andBool  #rangeSInt(256, B)
+ 
+

--- a/spec_hold_fail.ini
+++ b/spec_hold_fail.ini
@@ -1,0 +1,32 @@
+[hold]
+k: #execute => #halt
+statusCode: _ => EVMC_REVERT
+output: _ => _
+callData: #abiCallData("hold", #bytes32(Ilk), #int256(NewQ))
+localMem: _
+pc: 0 => _
+wordStack: .WordStack => _
+gas: Gas => _
+log: _
+callDepth: _
+refund: _ => _
+storage:
+  0 |-> Root
+  (#hashedLocation("DappHub", 4, Ilk) |-> (#unsigned(Q) => _))
+  _:Map
+activeaccounts:
+accounts:
+requires:
+  andBool Gas >Int 100000
+  andBool #rangeAddress(Root)
+  andBool #rangeBytes(32, Ilk)
+  andBool #rangeSInt(256, NewQ)
+
+  // negation of success conditions (in order):
+  andBool notBool (
+    Root ==Int CALLER_ID
+    andBool (NewQ >=Int 0)
+  )
+
+attribute:
+

--- a/spec_hold_success.ini
+++ b/spec_hold_success.ini
@@ -1,0 +1,30 @@
+[hold]
+k: #execute => #halt
+statusCode: _ => EVMC_SUCCESS
+output: _ => _
+callData: #abiCallData("hold", #bytes32(Ilk), #int256(NewQ))
+localMem: _
+pc: 0 => _
+wordStack: .WordStack => _
+gas: Gas => _
+log: _
+callDepth: _
+refund: _ => _
+storage:
+  0 |-> Root
+  (#hashedLocation("DappHub", 8, Ilk) |-> (#unsigned(Q) => NewQ))
+  _:Map
+activeaccounts:
+accounts:
+requires:
+  andBool Gas >Int 100000
+  andBool #rangeAddress(Root)
+  andBool #rangeBytes(32, Ilk)
+  andBool #rangeSInt(256, NewQ)
+
+  // success conditions (in order):
+  andBool Root ==Int CALLER_ID
+  andBool (NewQ >=Int 0)
+
+attribute:
+

--- a/spec_suck_fail.ini
+++ b/spec_suck_fail.ini
@@ -1,0 +1,46 @@
+[suck]
+k: #execute => #halt
+statusCode: _ => EVMC_REVERT
+output: _ => _
+callData: #abiCallData("suck", #address(V_u), #int256(Delta_D))
+localMem: _
+pc: 0 => _
+wordStack: .WordStack => _
+gas: Gas => _
+log: _
+callDepth: _
+refund: _ => _
+storage:
+  0 |-> Root
+  9 |-> #unsigned(V_p)
+  10 |-> #unsigned(P)
+  11 |-> (#unsigned(V) => _)
+  12 |-> G
+  (#hashedLocation("DappHub", 4, V_u) |-> (#unsigned(D_u) => _))
+  _:Map
+activeaccounts:
+accounts:
+requires:
+  andBool Gas >Int 100000
+  andBool #rangeUInt(256, G)
+  andBool #rangeAddress(Root)
+  andBool #rangeAddress(User)
+  andBool #rangeAddress(V_u)
+  andBool #rangeSInt(256, V)
+  andBool #rangeSInt(256, P)
+  andBool #rangeSInt(256, D_u)
+  andBool #rangeSInt(256, Delta_D)
+  andBool #rangeSInt(256, V_p)
+  andBool User ==Int V_u
+
+  // negation of success conditions:
+  andBool notBool (
+    Root ==Int CALLER_ID
+    andBool #rangeSInt(256, V -Int Delta_D)
+    //andBool V -Int Delta_D >=Int 0
+    //andBool #rangeSInt(256, D_u +Int Delta_D)
+    //andBool D_u +Int Delta_D >=Int 0
+  )
+
+attribute:
+

--- a/spec_suck_success.ini
+++ b/spec_suck_success.ini
@@ -1,0 +1,44 @@
+[suck]
+k: #execute => #halt
+statusCode: _ => EVMC_SUCCESS
+output: _ => _
+callData: #abiCallData("suck", #address(V_u), #int256(Delta_D))
+localMem: _
+pc: 0 => _
+wordStack: .WordStack => _
+gas: Gas => _
+log: _
+callDepth: _
+refund: _
+storage:
+  0 |-> Root
+  9 |-> #unsigned(V_p)
+  10 |-> #unsigned(P)
+  11 |-> (#unsigned(V) => V -Int Delta_D)
+  12 |-> G
+  (#hashedLocation("DappHub", 4, V_u) |-> (#unsigned(D_u) => D_u +Int Delta_D))
+  _:Map
+activeaccounts:
+accounts:
+requires:
+  andBool Gas >Int 100000
+  andBool #rangeUInt(256, G)
+  andBool #rangeAddress(Root)
+  andBool #rangeAddress(User)
+  andBool #rangeAddress(V_u)
+  andBool #rangeSInt(256, V)
+  andBool #rangeSInt(256, P)
+  andBool #rangeSInt(256, D_u)
+  andBool #rangeSInt(256, Delta_D)
+  andBool #rangeSInt(256, V_p)
+  andBool User ==Int V_u
+  
+  // success conditions (in order):
+  andBool Root ==Int CALLER_ID
+  andBool #rangeSInt(256, V -Int Delta_D)
+  andBool V -Int Delta_D >=Int 0
+  andBool #rangeSInt(256, D_u +Int Delta_D)
+  andBool D_u +Int Delta_D >=Int 0
+
+attribute:
+


### PR DESCRIPTION
These lemmas establish soundness of the overflow checks in `iadd` and `isub`, i.e. they tell us that if the overflow check passed, then the sum or difference was within the range of signed integers. They are necessary probably because the result requires a bit of modular arithmetic, I suppose Z3 can't discharge it. It also helps to have 3 basic propositional rules.

These lemmas are enough to prove the revert cases of: `iadd` and `isub`, and therefore of `suck`, `hold`, etc. The revert case of `burn` is currently failing due to some ABI-related issue that I am investigating.